### PR TITLE
RB lookup can no longer rely on the fixed supported languages list

### DIFF
--- a/src/main/java/com/ibm/g11n/pipeline/client/rb/CloudResourceBundle.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/rb/CloudResourceBundle.java
@@ -54,7 +54,7 @@ public final class CloudResourceBundle extends ResourceBundle {
             Map<String, String> resStrings = client.getResourceStrings(bundleId, locale.toLanguageTag(), false);
             crb = new CloudResourceBundle(resStrings);
         } catch (ServiceException e) {
-            logger.warning("An error occurred while loading resource data for " + locale
+            logger.info("Could not fetch resource data for " + locale
                     + " from the translation bundle " + bundleId + ": " + e.getMessage());
         }
         return crb;

--- a/src/main/java/com/ibm/g11n/pipeline/client/rb/package-info.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/rb/package-info.java
@@ -82,6 +82,6 @@
  * classpath can be done by
  * <a href="https://www.ng.bluemix.net/docs/starters/liberty/index.html#customizingjre">Customizing
  * the JRE</a>. The SDK jar file should be placed in resources/.java-overlay/.java/.jre/lib/ext
- * folder in your application pacakge.
+ * folder in your application package.
  */
 package com.ibm.g11n.pipeline.client.rb;


### PR DESCRIPTION
GP service no longer limits languages to be used in service intances.
Previously resource bundle lookup code checks /$service/v2/info to get
the set of all supported languages (and cache them), so it could check a
language which was never supported quickly. But, with the change,
resource bundle lookup code must query GP REST server to see if a given
language really exists for every bundle.
This commit removes isLocaleSupportedByService(Locale) from
CloudResourceBundleControl. CloudResourceBundle#loadBundle() no longer
emit warning to logger, because absense of language is expected in
common use cases. This commit fixes #15.
